### PR TITLE
Fixed typo in footer

### DIFF
--- a/content.html
+++ b/content.html
@@ -411,7 +411,7 @@ for (var i = test_strings.length - 1; i >= 0; i--) {
 
       <ul class="col-2">
         <li><strong>Authoriser:</strong>
-          <br>Communcations Manager</li>
+          <br>Communications Manager</li>
         <li><strong>Maintainer:</strong><br>
           Pat Doe, Faculty of Bar</li>
       </ul>


### PR DESCRIPTION
Noticed this typo in the D7 theme and found it was also in the core templates. Here is a patch, please merge.
