### PR TITLE
Keep menu expand when items in menu tree is active

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -207,7 +207,7 @@
   // Injects all the extra elements required by the nested show/hide nav
   function initNestedNav(li) {
 	//Open sub-menu if it is in active-trail, else close it.
-    if(li.childNodes[0].className == 'active-trail current-parent') {
+    if(li.childNodes[0].className == 'active-trail current-parent' || li.childNodes[0].className == 'current') {
 		li.className += ' open'; 
 		text = 'Less';
 	}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -206,7 +206,15 @@
   }
   // Injects all the extra elements required by the nested show/hide nav
   function initNestedNav(li) {
-    li.className += ' closed';
+	//Open sub-menu if it is in active-trail, else close it.
+    if(li.childNodes[0].className == 'active-trail current-parent') {
+		li.className += ' open'; 
+		text = 'Less';
+	}
+	else {
+		li.className += ' closed';
+		text = 'More';
+	}
     var ul = Navigation.findChildrenByTag(li.childNodes, 'UL')[0] || li.firstChild,
         a = document.createElement('a'),
         text = document.createTextNode('More');


### PR DESCRIPTION
Problem: All sub-menus are collapsed initially regardless of the current active page.

dc8ad48: Expand menu when child is the active page
In function initNestedNav(), check if menu has class 'active-trail current-parent' to decide whether submenu is open or not.

3a1a7d5: Expand sub-menu when parent is the active page 
In function initNestedNav(), check if menu has class 'current' to decide whether submenu is open or not.
